### PR TITLE
Minor fix.

### DIFF
--- a/tf_dataset_samples/ds_generator.py
+++ b/tf_dataset_samples/ds_generator.py
@@ -31,11 +31,11 @@ def create_dataset():
   data = data.batch(2)
   data = data.make_one_shot_iterator()
   tt = time.time()
+  _, labels = data.get_next()
   with tf.Session() as sess:
     for i in range(100):
-      _, labels = data.get_next()
-      labels = sess.run(labels)
-      print('{} -> {}'.format(i, labels))
+      getlabels = sess.run(labels)
+      print('{} -> {}'.format(i, getlabels))
     print(time.time() - tt)
 
 


### PR DESCRIPTION
Fix warning:
"UserWarning: An unusually high number of `Iterator.get_next()` calls was detected.
This often indicates that `Iterator.get_next()` is being called inside a training loop,
which will cause gradual slowdown and eventual resource exhaustion.
If this is the case, restructure your code to call `next_element = iterator.get_next()` once outside the loop,
and use `next_element` as the input to some computation that is invoked inside the loop.
warnings.warn(GET_NEXT_CALL_WARNING_MESSAGE)
"